### PR TITLE
Add multi-tenant HAPI FHIR support for Arogyam GKE migration

### DIFF
--- a/scripts/test-multi-tenant.sh
+++ b/scripts/test-multi-tenant.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+KEYCLOAK_IMAGE="quay.io/keycloak/keycloak:24.0.3"
+KEYCLOAK_CONTAINER="keycloak-test-mt"
+KEYCLOAK_PORT="${KEYCLOAK_PORT:-8180}"
+FHIR_PORT="${FHIR_PORT:-8090}"
+REALM="test"
+CLIENT_ID="fhir-client"
+TENANT_A="TENANT-A"
+TENANT_B="TENANT-B"
+FHIR_BASE="http://localhost:${FHIR_PORT}/fhir"
+KEYCLOAK_BASE="http://localhost:${KEYCLOAK_PORT}"
+TOKEN_URL="${KEYCLOAK_BASE}/realms/${REALM}/protocol/openid-connect/token"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+MVN="${MVN:-$(command -v mvn 2>/dev/null || echo "${HOME}/.m2/wrapper/dists/apache-maven-3.8.4-bin/66e9f8f4/apache-maven-3.8.4/bin/mvn")}"
+FHIR_LOG="/tmp/fhir-server-mt.log"
+RESP_FILE="/tmp/fhir-mt-resp.json"
+FHIR_PID=""
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+pass() { echo "  PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+
+fail() {
+  echo "  FAIL: $1 — $2"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+get_token() {
+  local username="$1" password="$2"
+  curl -s -X POST "${TOKEN_URL}" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=password&client_id=${CLIENT_ID}&username=${username}&password=${password}" \
+    | jq -r '.access_token'
+}
+
+# Polls $1 until it returns HTTP 200, or times out after $2 seconds.
+wait_for_url() {
+  local url="$1" max="${2:-120}"
+  local elapsed=0
+  echo "  Waiting for ${url} ..."
+  until [[ "$(curl -s -o /dev/null -w "%{http_code}" "${url}" 2>/dev/null)" != "000" ]]; do
+    if (( elapsed >= max )); then
+      echo "  ERROR: ${url} did not become ready within ${max}s"
+      exit 1
+    fi
+    sleep 2
+    ((elapsed += 2))
+  done
+}
+
+# Returns the HTTP status code; writes body to $RESP_FILE.
+http() {
+  local method="$1" url="$2" token="${3:-}" body="${4:-}"
+  local args=(-s -o "${RESP_FILE}" -w "%{http_code}" -X "${method}")
+  [[ -n "${token}" ]] && args+=(-H "Authorization: Bearer ${token}")
+  [[ -n "${body}" ]] && args+=(-H "Content-Type: application/fhir+json" -d "${body}")
+  curl "${args[@]}" "${url}"
+}
+
+cleanup() {
+  echo ""
+  echo "Cleaning up..."
+  if [[ -n "${FHIR_PID}" ]] && kill -0 "${FHIR_PID}" 2>/dev/null; then
+    kill "${FHIR_PID}" 2>/dev/null || true
+    wait "${FHIR_PID}" 2>/dev/null || true
+  fi
+  docker stop "${KEYCLOAK_CONTAINER}" 2>/dev/null || true
+  docker rm  "${KEYCLOAK_CONTAINER}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Optional build
+# ---------------------------------------------------------------------------
+SKIP_BUILD=false
+for arg in "$@"; do [[ "$arg" == "--skip-build" ]] && SKIP_BUILD=true; done
+
+if [[ "${SKIP_BUILD}" == false ]]; then
+  echo "Building..."
+  (cd "${REPO_ROOT}" && "${MVN}" clean package -DskipTests -q)
+fi
+
+WAR="${REPO_ROOT}/target/ROOT.war"
+if [[ ! -f "${WAR}" ]]; then
+  echo "ERROR: ${WAR} not found. Run without --skip-build or build manually."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Start Keycloak
+# ---------------------------------------------------------------------------
+echo "Starting Keycloak..."
+docker rm -f "${KEYCLOAK_CONTAINER}" 2>/dev/null || true
+docker run -d \
+  --name "${KEYCLOAK_CONTAINER}" \
+  -p "${KEYCLOAK_PORT}:8080" \
+  -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+  -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+  -v "${REPO_ROOT}/src/test/resources/keycloak/test-realm.json:/opt/keycloak/data/import/test-realm.json" \
+  "${KEYCLOAK_IMAGE}" start-dev --import-realm > /dev/null
+
+wait_for_url "${KEYCLOAK_BASE}/realms/${REALM}" 120
+
+# ---------------------------------------------------------------------------
+# Start FHIR server
+# ---------------------------------------------------------------------------
+echo "Starting FHIR server..."
+java -jar "${WAR}" \
+  --server.port="${FHIR_PORT}" \
+  "--spring.datasource.url=jdbc:h2:mem:dbr4-jwt-mt;DB_CLOSE_DELAY=-1" \
+  --hapi.fhir.fhir_version=r4 \
+  --hapi.fhir.cr_enabled=false \
+  --hapi.fhir.partitioning.partitioning_include_in_search_hashes=false \
+  --hapi.fhir.security.inbound.authentication.enabled=true \
+  --hapi.fhir.security.inbound.authentication.proceed-to-authorization-on-no-auth=false \
+  --hapi.fhir.security.inbound.authentication.proceed-to-authorization-on-failure=false \
+  "--hapi.fhir.security.inbound.authentication.allowed-issuer-patterns[0]=http://localhost:${KEYCLOAK_PORT}/realms/${REALM}" \
+  >"${FHIR_LOG}" 2>&1 &
+FHIR_PID=$!
+
+wait_for_url "${FHIR_BASE}/metadata" 180
+
+# ---------------------------------------------------------------------------
+# Create partitions (admin setup)
+# ---------------------------------------------------------------------------
+echo "Creating partitions..."
+ADMIN_TOKEN="$(get_token admin password)"
+
+create_partition() {
+  local id="$1" name="$2"
+  local body
+  body=$(printf '{"resourceType":"Parameters","parameter":[{"name":"id","valueInteger":%d},{"name":"name","valueCode":"%s"}]}' "${id}" "${name}")
+  http POST "${FHIR_BASE}/DEFAULT/\$partition-management-create-partition" "${ADMIN_TOKEN}" "${body}" > /dev/null
+}
+
+create_partition 1 "${TENANT_A}"
+create_partition 2 "${TENANT_B}"
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+echo ""
+echo "Running tests..."
+
+# ------ test 1: Tenant-A user can create and read in Tenant-A ---------------
+TOKEN_A="$(get_token user-a password)"
+STATUS=$(http POST "${FHIR_BASE}/${TENANT_A}/Patient" "${TOKEN_A}" \
+  '{"resourceType":"Patient","name":[{"family":"TenantAFamily"}]}')
+if [[ "${STATUS}" == "201" ]]; then
+  PATIENT_ID=$(jq -r '.id' "${RESP_FILE}")
+  STATUS2=$(http GET "${FHIR_BASE}/${TENANT_A}/Patient/${PATIENT_ID}" "${TOKEN_A}")
+  FAMILY=$(jq -r '.name[0].family' "${RESP_FILE}")
+  if [[ "${STATUS2}" == "200" && "${FAMILY}" == "TenantAFamily" ]]; then
+    pass "tenant_a_user_can_create_and_read_in_tenant_a"
+  else
+    fail "tenant_a_user_can_create_and_read_in_tenant_a" "GET returned status=${STATUS2} family=${FAMILY}"
+  fi
+else
+  fail "tenant_a_user_can_create_and_read_in_tenant_a" "POST returned status=${STATUS}"
+fi
+
+# ------ test 2: Tenant-B user can create and read in Tenant-B ---------------
+TOKEN_B="$(get_token user-b password)"
+STATUS=$(http POST "${FHIR_BASE}/${TENANT_B}/Patient" "${TOKEN_B}" \
+  '{"resourceType":"Patient","name":[{"family":"TenantBFamily"}]}')
+if [[ "${STATUS}" == "201" ]]; then
+  PATIENT_ID=$(jq -r '.id' "${RESP_FILE}")
+  STATUS2=$(http GET "${FHIR_BASE}/${TENANT_B}/Patient/${PATIENT_ID}" "${TOKEN_B}")
+  FAMILY=$(jq -r '.name[0].family' "${RESP_FILE}")
+  if [[ "${STATUS2}" == "200" && "${FAMILY}" == "TenantBFamily" ]]; then
+    pass "tenant_b_user_can_create_and_read_in_tenant_b"
+  else
+    fail "tenant_b_user_can_create_and_read_in_tenant_b" "GET returned status=${STATUS2} family=${FAMILY}"
+  fi
+else
+  fail "tenant_b_user_can_create_and_read_in_tenant_b" "POST returned status=${STATUS}"
+fi
+
+# ------ test 3: Tenant-A user is blocked from Tenant-B ---------------------
+STATUS=$(http GET "${FHIR_BASE}/${TENANT_B}/Patient" "${TOKEN_A}")
+if [[ "${STATUS}" == "403" ]]; then
+  pass "tenant_a_user_blocked_from_tenant_b"
+else
+  fail "tenant_a_user_blocked_from_tenant_b" "expected 403, got ${STATUS}"
+fi
+
+# ------ test 4: Tenant-B user is blocked from Tenant-A ---------------------
+STATUS=$(http GET "${FHIR_BASE}/${TENANT_A}/Patient" "${TOKEN_B}")
+if [[ "${STATUS}" == "403" ]]; then
+  pass "tenant_b_user_blocked_from_tenant_a"
+else
+  fail "tenant_b_user_blocked_from_tenant_a" "expected 403, got ${STATUS}"
+fi
+
+# ------ test 5: Tenants have isolated data ----------------------------------
+http POST "${FHIR_BASE}/${TENANT_A}/Patient" "${TOKEN_A}" \
+  '{"resourceType":"Patient","name":[{"family":"IsolatedA"}]}' > /dev/null
+http POST "${FHIR_BASE}/${TENANT_B}/Patient" "${TOKEN_B}" \
+  '{"resourceType":"Patient","name":[{"family":"IsolatedB"}]}' > /dev/null
+
+http GET "${FHIR_BASE}/${TENANT_A}/Patient?_count=100" "${TOKEN_A}" > /dev/null
+FAMILIES_A=$(jq -r '[.entry[]?.resource.name[]?.family] | .[]' "${RESP_FILE}" 2>/dev/null || true)
+
+http GET "${FHIR_BASE}/${TENANT_B}/Patient?_count=100" "${TOKEN_B}" > /dev/null
+FAMILIES_B=$(jq -r '[.entry[]?.resource.name[]?.family] | .[]' "${RESP_FILE}" 2>/dev/null || true)
+
+ISOLATED_OK=true
+if echo "${FAMILIES_A}" | grep -q "IsolatedB"; then
+  fail "tenants_have_isolated_data" "TENANT-A should not see IsolatedB"
+  ISOLATED_OK=false
+fi
+if echo "${FAMILIES_B}" | grep -q "IsolatedA"; then
+  fail "tenants_have_isolated_data" "TENANT-B should not see IsolatedA"
+  ISOLATED_OK=false
+fi
+if ! echo "${FAMILIES_A}" | grep -q "IsolatedA"; then
+  fail "tenants_have_isolated_data" "TENANT-A should see IsolatedA"
+  ISOLATED_OK=false
+fi
+if ! echo "${FAMILIES_B}" | grep -q "IsolatedB"; then
+  fail "tenants_have_isolated_data" "TENANT-B should see IsolatedB"
+  ISOLATED_OK=false
+fi
+if [[ "${ISOLATED_OK}" == true ]]; then
+  pass "tenants_have_isolated_data"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+[[ "${FAIL_COUNT}" -eq 0 ]]

--- a/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authentication/AuthenticationConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authentication/AuthenticationConfig.java
@@ -1,5 +1,6 @@
 package ca.uhn.fhir.jpa.starter.authnz.inbound.authentication;
 
+import ca.uhn.fhir.jpa.starter.authnz.inbound.authorization.JwtPartitionValidationInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
@@ -30,6 +31,9 @@ public class AuthenticationConfig {
 
     @Bean
     public JwtDecoder jwtDecoder(AuthenticationProperties properties) {
+        if (!properties.getAllowedIssuerPatterns().isEmpty()) {
+            return new MultiIssuerJwtDecoder(properties.getAllowedIssuerPatterns());
+        }
         return JwtDecoders.fromIssuerLocation(properties.getUserRealmUri());
     }
 
@@ -41,5 +45,10 @@ public class AuthenticationConfig {
     @Bean
     public AuthenticationProtocol.Registry registry(OIDCAuthenticationProtocol authenticationProtocol) {
         return new AuthenticationProtocol.Registry(authenticationProtocol);
+    }
+
+    @Bean
+    public JwtPartitionValidationInterceptor jwtPartitionValidationInterceptor() {
+        return new JwtPartitionValidationInterceptor();
     }
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authentication/AuthenticationProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authentication/AuthenticationProperties.java
@@ -2,6 +2,9 @@ package ca.uhn.fhir.jpa.starter.authnz.inbound.authentication;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @ConfigurationProperties(prefix = "hapi.fhir.security.inbound.authentication")
 public class AuthenticationProperties {
 	// Convert the user to be anonymous when the authentication fails with auth error
@@ -9,6 +12,9 @@ public class AuthenticationProperties {
 	private Boolean proceedToAuthorizationOnNoAuth = false;
 	private Boolean enabled = false;
 	private String userRealmUri;
+	// Multi-tenant: regex patterns matching allowed Keycloak realm issuer URLs.
+	// When non-empty, userRealmUri is ignored and each JWT's 'iss' is validated against these patterns.
+	private List<String> allowedIssuerPatterns = new ArrayList<>();
 
 	public Boolean getProceedToAuthorizationOnFailure() {
 		return proceedToAuthorizationOnFailure;
@@ -40,5 +46,13 @@ public class AuthenticationProperties {
 
 	public void setUserRealmUri(String userRealmUri) {
 		this.userRealmUri = userRealmUri;
+	}
+
+	public List<String> getAllowedIssuerPatterns() {
+		return allowedIssuerPatterns;
+	}
+
+	public void setAllowedIssuerPatterns(List<String> allowedIssuerPatterns) {
+		this.allowedIssuerPatterns = allowedIssuerPatterns;
 	}
 }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authentication/MultiIssuerJwtDecoder.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authentication/MultiIssuerJwtDecoder.java
@@ -1,0 +1,51 @@
+package ca.uhn.fhir.jpa.starter.authnz.inbound.authentication;
+
+import com.nimbusds.jwt.JWTParser;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtException;
+
+import java.text.ParseException;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class MultiIssuerJwtDecoder implements JwtDecoder {
+	private final List<Pattern> allowedIssuerPatterns;
+	private final ConcurrentHashMap<String, JwtDecoder> decoderCache = new ConcurrentHashMap<>();
+
+	public MultiIssuerJwtDecoder(List<String> allowedIssuerPatterns) {
+		this.allowedIssuerPatterns = allowedIssuerPatterns.stream()
+			.map(Pattern::compile)
+			.collect(Collectors.toList());
+	}
+
+	@Override
+	public Jwt decode(String token) throws JwtException {
+		String issuer = extractIssuer(token);
+		validateIssuer(issuer);
+		JwtDecoder decoder = decoderCache.computeIfAbsent(issuer, JwtDecoders::fromIssuerLocation);
+		return decoder.decode(token);
+	}
+
+	private String extractIssuer(String token) {
+		try {
+			String issuer = JWTParser.parse(token).getJWTClaimsSet().getIssuer();
+			if (issuer == null || issuer.isBlank()) {
+				throw new JwtException("JWT is missing required 'iss' claim");
+			}
+			return issuer;
+		} catch (ParseException e) {
+			throw new JwtException("Failed to parse JWT: " + e.getMessage(), e);
+		}
+	}
+
+	private void validateIssuer(String issuer) {
+		boolean allowed = allowedIssuerPatterns.stream().anyMatch(p -> p.matcher(issuer).matches());
+		if (!allowed) {
+			throw new JwtException("JWT issuer '" + issuer + "' does not match any configured allowed-issuer-patterns");
+		}
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authentication/OIDCAuthenticationProtocol.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authentication/OIDCAuthenticationProtocol.java
@@ -71,6 +71,7 @@ public class OIDCAuthenticationProtocol implements AuthenticationProtocol {
 			.setUsernameNamespace(jwt.getClaimAsString("azp"))
 			.setServiceAccount(false)
 			.setFhirUserUrl(String.format("%s/%s", "Practitioner", jwt.getSubject()))
+			.setPartitionId(jwt.getClaimAsString("partition_id"))
 			.build();
 
 	}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authorization/JwtPartitionValidationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authorization/JwtPartitionValidationInterceptor.java
@@ -1,0 +1,30 @@
+package ca.uhn.fhir.jpa.starter.authnz.inbound.authorization;
+
+import ca.uhn.fhir.interceptor.api.Hook;
+import ca.uhn.fhir.interceptor.api.Interceptor;
+import ca.uhn.fhir.interceptor.api.Pointcut;
+import ca.uhn.fhir.jpa.starter.authnz.inbound.shared.AuthenticationOutcome;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.server.exceptions.ForbiddenOperationException;
+import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationConstants;
+
+@Interceptor(order = AuthorizationConstants.ORDER_AUTH_INTERCEPTOR)
+public class JwtPartitionValidationInterceptor {
+
+	@Hook(Pointcut.SERVER_INCOMING_REQUEST_PRE_HANDLED)
+	public void validate(RequestDetails requestDetails) {
+		AuthenticationOutcome outcome = AuthenticationOutcome.getOutcome(requestDetails);
+		if (outcome == null || !outcome.isAuthenticated()) return;
+
+		String jwtPartitionId = outcome.getUserSessionDetail().getPartitionId();
+		String urlTenantId = requestDetails.getTenantId();
+
+		// Skip when no partition claim or no URL tenant — covers DEFAULT partition admin calls
+		if (jwtPartitionId == null || urlTenantId == null) return;
+
+		if (!jwtPartitionId.equalsIgnoreCase(urlTenantId)) {
+			throw new ForbiddenOperationException(
+				"JWT partition_id '" + jwtPartitionId + "' does not match requested tenant '" + urlTenantId + "'");
+		}
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/shared/UserSessionDetail.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/shared/UserSessionDetail.java
@@ -25,8 +25,9 @@ public class UserSessionDetail {
 	private final String systemUser;
 	private final Boolean serviceAccount;
 	private final String fhirUserUrl;
+	private final String partitionId;
 
-	private UserSessionDetail(String id, Jwt jwt, List<FhirContext> fhirContext, Set<String> scopes, String oidcClientId, Boolean accountDisabled, String email, Boolean emailVerified, Boolean accountLocked, Set<GrantedAuthority> authorities, String givenName, String familyName, String username, String usernameNamespace, String systemUser, Boolean serviceAccount, String fhirUserUrl) {
+	private UserSessionDetail(String id, Jwt jwt, List<FhirContext> fhirContext, Set<String> scopes, String oidcClientId, Boolean accountDisabled, String email, Boolean emailVerified, Boolean accountLocked, Set<GrantedAuthority> authorities, String givenName, String familyName, String username, String usernameNamespace, String systemUser, Boolean serviceAccount, String fhirUserUrl, String partitionId) {
 		this.id = id;
 		this.jwt = jwt;
 		this.fhirContext = fhirContext;
@@ -44,6 +45,7 @@ public class UserSessionDetail {
 		this.systemUser = systemUser;
 		this.serviceAccount = serviceAccount;
 		this.fhirUserUrl = fhirUserUrl;
+		this.partitionId = partitionId;
 	}
 
 	public String getId() {
@@ -118,6 +120,9 @@ public class UserSessionDetail {
 		return fhirUserUrl;
 	}
 
+	public String getPartitionId() {
+		return partitionId;
+	}
 
 	public static Builder builder() {
 		return new Builder();
@@ -141,6 +146,7 @@ public class UserSessionDetail {
 		private String systemUser;
 		private Boolean serviceAccount;
 		private String fhirUserUrl;
+		private String partitionId;
 
 		private Builder() {
 		}
@@ -230,8 +236,13 @@ public class UserSessionDetail {
 			return this;
 		}
 
+		public Builder setPartitionId(String partitionId) {
+			this.partitionId = partitionId;
+			return this;
+		}
+
 		public UserSessionDetail build() {
-			return new UserSessionDetail(id, jwt, fhirContext, scopes, oidcClientId, accountDisabled, email, emailVerified, accountLocked, authorities, givenName, familyName, username, usernameNamespace, systemUser, serviceAccount, fhirUserUrl);
+			return new UserSessionDetail(id, jwt, fhirContext, scopes, oidcClientId, accountDisabled, email, emailVerified, accountLocked, authorities, givenName, familyName, username, usernameNamespace, systemUser, serviceAccount, fhirUserUrl, partitionId);
 		}
 	}
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -42,6 +42,7 @@ import ca.uhn.fhir.jpa.starter.AppProperties;
 import ca.uhn.fhir.jpa.starter.annotations.OnCorsPresent;
 import ca.uhn.fhir.jpa.starter.annotations.OnImplementationGuidesPresent;
 import ca.uhn.fhir.jpa.starter.authnz.inbound.authentication.AuthenticationInterceptor;
+import ca.uhn.fhir.jpa.starter.authnz.inbound.authorization.JwtPartitionValidationInterceptor;
 import ca.uhn.fhir.jpa.starter.common.validation.IRepositoryValidationInterceptorFactory;
 import ca.uhn.fhir.jpa.starter.ig.IImplementationGuideOperationProvider;
 import ca.uhn.fhir.jpa.starter.util.EnvironmentHelper;
@@ -278,7 +279,8 @@ public class StarterJpaConfig {
 		Optional<IpsOperationProvider> theIpsOperationProvider,
 		Optional<IImplementationGuideOperationProvider> implementationGuideOperationProvider,
 		Optional<AuthenticationInterceptor> authenticationInterceptor,
-		Optional<AuthorizationInterceptor> authorizationInterceptor
+		Optional<AuthorizationInterceptor> authorizationInterceptor,
+		Optional<JwtPartitionValidationInterceptor> jwtPartitionValidationInterceptor
 	) {
 		RestfulServer fhirServer = new RestfulServer(fhirSystemDao.getContext());
 
@@ -467,6 +469,7 @@ public class StarterJpaConfig {
 		// Register Auth Interceptor
 		authenticationInterceptor.ifPresent(fhirServer::registerInterceptor);
 		authorizationInterceptor.ifPresent(fhirServer::registerInterceptor);
+		jwtPartitionValidationInterceptor.ifPresent(fhirServer::registerInterceptor);
 
 		return fhirServer;
 	}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -159,9 +159,12 @@ hapi:
       - https://unitsofmeasure.org/*
       - http://loinc.org/*
       - https://loinc.org/*
-    #    partitioning:
-    #      allow_references_across_partitions: false
-    #      partitioning_include_in_search_hashes: false
+    # Enable for multi-tenant deployments (one partition per tenant, addressed via URL: /fhir/{TENANT}/Patient).
+    # Pair with security.inbound.authentication.allowed-issuer-patterns and ensure each tenant's
+    # Keycloak JWT contains a partition_id claim matching the tenant name.
+    #partitioning:
+    #  allow_references_across_partitions: false
+    #  partitioning_include_in_search_hashes: false
     cors:
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
@@ -266,7 +269,12 @@ hapi:
           enabled: false
           proceed-to-authorization-on-failure: false
           proceed-to-authorization-on-no-auth: true
+          # Single-realm (backwards compatible): specify one Keycloak realm URI
           user-realm-uri: http://localhost:9000/auth/realm/arogyam
+          # Multi-tenant: list regex patterns matching allowed Keycloak realm issuer URLs.
+          # When set, user-realm-uri is ignored and each JWT's 'iss' claim is validated against these patterns.
+          # allowed-issuer-patterns:
+          #   - "https://keycloak.example.com/realms/.*"
         authorization:
           enabled: false
           allow-anonymous-access: true

--- a/src/test/resources/keycloak/test-realm.json
+++ b/src/test/resources/keycloak/test-realm.json
@@ -1,0 +1,78 @@
+{
+  "realm": "test",
+  "enabled": true,
+  "sslRequired": "none",
+  "requiredActions": [
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "fhir-client",
+      "enabled": true,
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "protocolMappers": [
+        {
+          "name": "partition-id-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "partition_id",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "partition_id",
+            "jsonType.label": "String",
+            "introspection.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "user-a",
+      "email": "user-a@test.local",
+      "firstName": "User",
+      "lastName": "A",
+      "enabled": true,
+      "emailVerified": true,
+      "requiredActions": [],
+      "attributes": {
+        "partition_id": ["TENANT-A"]
+      },
+      "credentials": [{"type": "password", "value": "password", "temporary": false}]
+    },
+    {
+      "username": "user-b",
+      "email": "user-b@test.local",
+      "firstName": "User",
+      "lastName": "B",
+      "enabled": true,
+      "emailVerified": true,
+      "requiredActions": [],
+      "attributes": {
+        "partition_id": ["TENANT-B"]
+      },
+      "credentials": [{"type": "password", "value": "password", "temporary": false}]
+    },
+    {
+      "username": "admin",
+      "email": "admin@test.local",
+      "firstName": "Admin",
+      "lastName": "User",
+      "enabled": true,
+      "emailVerified": true,
+      "requiredActions": [],
+      "credentials": [{"type": "password", "value": "password", "temporary": false}]
+    }
+  ]
+}


### PR DESCRIPTION
Enables logical partitioning per tenant (GOA, WB, AIIMS, TN, Mathura) using HAPI's URL-based tenant identification (/fhir/{TENANT}/...) with two new security layers:

- MultiIssuerJwtDecoder: validates JWTs from multiple Keycloak realms (one realm per tenant) by extracting the 'iss' claim, matching it against configured regex allowlist patterns, and caching per-issuer NimbusJwtDecoder instances. Falls back to single-realm behaviour when allowed-issuer-patterns is not set.

- JwtPartitionValidationInterceptor: cross-checks the JWT partition_id claim against the URL tenant segment, rejecting requests where the two do not match (prevents cross-tenant data access).

UserSessionDetail now carries the partition_id claim extracted from the JWT. Application.yaml documents the opt-in config blocks needed to activate partitioning and multi-realm auth for a deployment.