### PR TITLE
Carve out SystemRequestDetails from tenant partition interceptor

### DIFF
--- a/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authorization/SystemAwareRequestTenantPartitionInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authorization/SystemAwareRequestTenantPartitionInterceptor.java
@@ -1,0 +1,21 @@
+package ca.uhn.fhir.jpa.starter.authnz.inbound.authorization;
+
+import ca.uhn.fhir.interceptor.model.RequestPartitionId;
+import ca.uhn.fhir.rest.api.server.RequestDetails;
+import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
+import ca.uhn.fhir.rest.server.interceptor.partition.RequestTenantPartitionInterceptor;
+
+// Stock RequestTenantPartitionInterceptor throws when a request has no tenant.
+// Server-internal work (e.g. search-parameter reindex on startup) issues
+// SystemRequestDetails without a URL tenant — route those to all partitions
+// instead so partitioning can be enabled without breaking boot.
+public class SystemAwareRequestTenantPartitionInterceptor extends RequestTenantPartitionInterceptor {
+
+	@Override
+	protected RequestPartitionId extractPartitionIdFromRequest(RequestDetails theRequestDetails) {
+		if (theRequestDetails instanceof SystemRequestDetails) {
+			return RequestPartitionId.allPartitions();
+		}
+		return super.extractPartitionIdFromRequest(theRequestDetails);
+	}
+}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -55,8 +55,8 @@ import ca.uhn.fhir.narrative.DefaultThymeleafNarrativeGenerator;
 import ca.uhn.fhir.narrative2.NullNarrativeGenerator;
 import ca.uhn.fhir.rest.api.IResourceSupportedSvc;
 import ca.uhn.fhir.rest.openapi.OpenApiInterceptor;
+import ca.uhn.fhir.jpa.starter.authnz.inbound.authorization.SystemAwareRequestTenantPartitionInterceptor;
 import ca.uhn.fhir.rest.server.interceptor.auth.AuthorizationInterceptor;
-import ca.uhn.fhir.rest.server.interceptor.partition.RequestTenantPartitionInterceptor;
 import ca.uhn.fhir.rest.server.*;
 import ca.uhn.fhir.rest.server.interceptor.*;
 import ca.uhn.fhir.rest.server.provider.ResourceProviderFactory;
@@ -449,7 +449,7 @@ public class StarterJpaConfig {
 
 		// Partitioning
 		if (appProperties.getPartitioning() != null) {
-			fhirServer.registerInterceptor(new RequestTenantPartitionInterceptor());
+			fhirServer.registerInterceptor(new SystemAwareRequestTenantPartitionInterceptor());
 			fhirServer.setTenantIdentificationStrategy(new UrlBaseTenantIdentificationStrategy());
 			fhirServer.registerProviders(partitionManagementProvider);
 		}


### PR DESCRIPTION
## Summary
- HAPI's stock `RequestTenantPartitionInterceptor` throws when a request has no tenant id. Server-internal work (e.g. search-parameter reindex on startup) issues `SystemRequestDetails` without a URL tenant, which blocks HAPI from booting with partitioning enabled.
- New `SystemAwareRequestTenantPartitionInterceptor` returns `RequestPartitionId.allPartitions()` for `SystemRequestDetails`, delegates everything else to super.
- Swapped registration in `StarterJpaConfig`.

## Test plan
- [x] `mvn compile` clean.
- [x] `scripts/test-multi-tenant.sh` — 5/5 passing (tenant A/B can write+read own data, cross-tenant blocked both ways, partitions isolated).
- [ ] Deploy to staging via aa-infra after image is published; HAPI boots cleanly with `hapi.fhir.partitioning.*` re-enabled.