### PR TITLE
Serve DEFAULT-only FHIR resource types from tenant URL reads

### DIFF
--- a/scripts/test-multi-tenant.sh
+++ b/scripts/test-multi-tenant.sh
@@ -67,6 +67,42 @@ http() {
   curl "${args[@]}" "${url}"
 }
 
+# Same as http(), but never sends an Authorization header (guards "fetched
+# before login" reads of shared config resources).
+http_no_auth() {
+  local method="$1" url="$2" body="${3:-}"
+  local args=(-s -o "${RESP_FILE}" -w "%{http_code}" -X "${method}")
+  [[ -n "${body}" ]] && args+=(-H "Content-Type: application/fhir+json" -d "${body}")
+  curl "${args[@]}" "${url}"
+}
+
+# Builds a minimal-but-valid FHIR body for a given resource type, with a
+# unique `identifier` so it can be looked up by search. Echoes JSON to stdout.
+# Usage: build_resource_body <ResourceType> <identifier-value>
+build_resource_body() {
+  local rtype="$1" ident="$2"
+  case "${rtype}" in
+    Composition)
+      printf '{"resourceType":"Composition","status":"final","identifier":{"system":"urn:test","value":"%s"},"type":{"text":"test"},"date":"2024-01-01","author":[{"display":"tester"}],"title":"test"}' "${ident}"
+      ;;
+    StructureMap)
+      printf '{"resourceType":"StructureMap","url":"http://example.org/StructureMap/%s","name":"%s","status":"draft","identifier":[{"system":"urn:test","value":"%s"}],"group":[{"name":"g","typeMode":"none","input":[{"name":"src","mode":"source"}],"rule":[]}]}' "${ident}" "${ident}" "${ident}"
+      ;;
+    Library)
+      printf '{"resourceType":"Library","status":"draft","type":{"text":"logic-library"},"identifier":[{"system":"urn:test","value":"%s"}]}' "${ident}"
+      ;;
+    Questionnaire)
+      printf '{"resourceType":"Questionnaire","status":"draft","identifier":[{"system":"urn:test","value":"%s"}]}' "${ident}"
+      ;;
+    PlanDefinition)
+      printf '{"resourceType":"PlanDefinition","status":"draft","identifier":[{"system":"urn:test","value":"%s"}]}' "${ident}"
+      ;;
+    *)
+      printf '{"resourceType":"%s","identifier":[{"system":"urn:test","value":"%s"}]}' "${rtype}" "${ident}"
+      ;;
+  esac
+}
+
 cleanup() {
   echo ""
   echo "Cleaning up..."
@@ -121,10 +157,19 @@ java -jar "${WAR}" \
   --hapi.fhir.fhir_version=r4 \
   --hapi.fhir.cr_enabled=false \
   --hapi.fhir.partitioning.partitioning_include_in_search_hashes=false \
+  "--hapi.fhir.partitioning.default_only_resource_types[0]=Composition" \
+  "--hapi.fhir.partitioning.default_only_resource_types[1]=StructureMap" \
+  "--hapi.fhir.partitioning.default_only_resource_types[2]=PlanDefinition" \
+  "--hapi.fhir.partitioning.default_only_resource_types[3]=Library" \
+  "--hapi.fhir.partitioning.default_only_resource_types[4]=Binary" \
+  "--hapi.fhir.partitioning.default_only_resource_types[5]=Location" \
+  "--hapi.fhir.partitioning.default_only_resource_types[6]=Questionnaire" \
   --hapi.fhir.security.inbound.authentication.enabled=true \
-  --hapi.fhir.security.inbound.authentication.proceed-to-authorization-on-no-auth=false \
+  --hapi.fhir.security.inbound.authentication.proceed-to-authorization-on-no-auth=true \
   --hapi.fhir.security.inbound.authentication.proceed-to-authorization-on-failure=false \
   "--hapi.fhir.security.inbound.authentication.allowed-issuer-patterns[0]=http://localhost:${KEYCLOAK_PORT}/realms/${REALM}" \
+  --hapi.fhir.security.inbound.authorization.enabled=true \
+  --hapi.fhir.security.inbound.authorization.allow-anonymous-access=true \
   >"${FHIR_LOG}" 2>&1 &
 FHIR_PID=$!
 
@@ -233,6 +278,135 @@ if ! echo "${FAMILIES_B}" | grep -q "IsolatedB"; then
 fi
 if [[ "${ISOLATED_OK}" == true ]]; then
   pass "tenants_have_isolated_data"
+fi
+
+# ---------------------------------------------------------------------------
+# Default-only-types interceptor tests
+#
+# These exercise SystemAwareRequestTenantPartitionInterceptor's
+# default-only-resource-types path: reads of configured types against
+# /fhir/<tenant>/<Type> are transparently served from DEFAULT, while writes
+# stay tenant-scoped (so a misconfigured client cannot silently mutate
+# shared config in DEFAULT).
+# ---------------------------------------------------------------------------
+
+# ------ test 6: Default-only read fallback (authenticated) -----------------
+# Seed each resource type in DEFAULT, then read it via /fhir/TENANT-A/...
+DEFAULT_ONLY_TYPES_AUTH=(Composition StructureMap Library)
+DEFAULT_ONLY_AUTH_OK=true
+for rtype in "${DEFAULT_ONLY_TYPES_AUTH[@]}"; do
+  IDENT="default-only-auth-${rtype}-$$-${RANDOM}"
+  BODY="$(build_resource_body "${rtype}" "${IDENT}")"
+  STATUS=$(http POST "${FHIR_BASE}/DEFAULT/${rtype}" "${ADMIN_TOKEN}" "${BODY}")
+  if [[ "${STATUS}" != "201" ]]; then
+    fail "default_only_read_fallback_authenticated" "POST ${rtype} to DEFAULT returned ${STATUS}"
+    DEFAULT_ONLY_AUTH_OK=false
+    continue
+  fi
+  CREATED_ID=$(jq -r '.id' "${RESP_FILE}")
+  STATUS2=$(http GET "${FHIR_BASE}/${TENANT_A}/${rtype}?identifier=${IDENT}" "${TOKEN_A}")
+  TOTAL=$(jq -r '.total // (.entry | length) // 0' "${RESP_FILE}" 2>/dev/null || echo 0)
+  FOUND_ID=$(jq -r '.entry[0].resource.id // ""' "${RESP_FILE}" 2>/dev/null || echo "")
+  if [[ "${STATUS2}" == "200" && "${TOTAL}" == "1" && "${FOUND_ID}" == "${CREATED_ID}" ]]; then
+    :
+  else
+    fail "default_only_read_fallback_authenticated" \
+      "GET ${rtype} from TENANT-A: status=${STATUS2} total=${TOTAL} found_id=${FOUND_ID} expected_id=${CREATED_ID}"
+    DEFAULT_ONLY_AUTH_OK=false
+  fi
+done
+if [[ "${DEFAULT_ONLY_AUTH_OK}" == true ]]; then
+  pass "default_only_read_fallback_authenticated"
+fi
+
+# ------ test 7: Default-only read fallback (unauthenticated) ---------------
+# Spot-check Composition + Questionnaire with NO Authorization header.
+# Guards the "fetched before login" constraint: the app pulls /Composition?
+# identifier=app from each tenant URL before any user has signed in.
+#
+# The server is started with:
+#   hapi.fhir.security.inbound.authorization.enabled=true
+#   hapi.fhir.security.inbound.authorization.allow-anonymous-access=true
+#   hapi.fhir.security.inbound.authentication.proceed-to-authorization-on-no-auth=true
+# The default anonymous-access-permission in application.yaml grants
+# fhir_read_all_of_type for Composition + Questionnaire (among others), so
+# anonymous reads of those types are permitted by authorization and the
+# default-only fallback transparently serves them from DEFAULT.
+DEFAULT_ONLY_TYPES_NOAUTH=(Composition Questionnaire)
+DEFAULT_ONLY_NOAUTH_OK=true
+for rtype in "${DEFAULT_ONLY_TYPES_NOAUTH[@]}"; do
+  IDENT="default-only-noauth-${rtype}-$$-${RANDOM}"
+  BODY="$(build_resource_body "${rtype}" "${IDENT}")"
+  STATUS=$(http POST "${FHIR_BASE}/DEFAULT/${rtype}" "${ADMIN_TOKEN}" "${BODY}")
+  if [[ "${STATUS}" != "201" ]]; then
+    fail "default_only_read_fallback_unauthenticated" "POST ${rtype} to DEFAULT returned ${STATUS}"
+    DEFAULT_ONLY_NOAUTH_OK=false
+    continue
+  fi
+  CREATED_ID=$(jq -r '.id' "${RESP_FILE}")
+  STATUS2=$(http_no_auth GET "${FHIR_BASE}/${TENANT_A}/${rtype}?identifier=${IDENT}")
+  TOTAL=$(jq -r '.total // (.entry | length) // 0' "${RESP_FILE}" 2>/dev/null || echo 0)
+  FOUND_ID=$(jq -r '.entry[0].resource.id // ""' "${RESP_FILE}" 2>/dev/null || echo "")
+  if [[ "${STATUS2}" == "200" && "${TOTAL}" == "1" && "${FOUND_ID}" == "${CREATED_ID}" ]]; then
+    :
+  else
+    fail "default_only_read_fallback_unauthenticated" \
+      "GET ${rtype} from TENANT-A no-auth: status=${STATUS2} total=${TOTAL} found_id=${FOUND_ID} expected_id=${CREATED_ID}"
+    DEFAULT_ONLY_NOAUTH_OK=false
+  fi
+done
+if [[ "${DEFAULT_ONLY_NOAUTH_OK}" == true ]]; then
+  pass "default_only_read_fallback_unauthenticated"
+fi
+
+# ------ test 8: Partition isolation still holds for non-default-only types -
+# Create a Patient on TENANT-A and ensure TENANT-B cannot read it by id.
+PT_BODY='{"resourceType":"Patient","name":[{"family":"IsolationRegressionA"}]}'
+STATUS=$(http POST "${FHIR_BASE}/${TENANT_A}/Patient" "${TOKEN_A}" "${PT_BODY}")
+if [[ "${STATUS}" == "201" ]]; then
+  PT_ID=$(jq -r '.id' "${RESP_FILE}")
+  STATUS2=$(http GET "${FHIR_BASE}/${TENANT_B}/Patient/${PT_ID}" "${TOKEN_B}")
+  if [[ "${STATUS2}" == "404" || "${STATUS2}" == "403" || "${STATUS2}" == "410" ]]; then
+    pass "partition_isolation_still_holds_for_patient"
+  else
+    fail "partition_isolation_still_holds_for_patient" "expected 404/403/410, got ${STATUS2}"
+  fi
+else
+  fail "partition_isolation_still_holds_for_patient" "POST Patient to TENANT-A returned ${STATUS}"
+fi
+
+# ------ test 9: Writes from a tenant URL are NOT rerouted to DEFAULT -------
+# A POST to /fhir/TENANT-A/Composition must NOT land in DEFAULT, even though
+# Composition is a default-only READ type. This is intentional: writes stay
+# tenant-scoped so a misconfigured client cannot mutate shared config.
+WRITE_IDENT="tenant-write-no-reroute-$$-${RANDOM}"
+WRITE_BODY="$(build_resource_body Composition "${WRITE_IDENT}")"
+# Status of the write itself is not asserted — success or refusal both fine.
+http POST "${FHIR_BASE}/${TENANT_A}/Composition" "${TOKEN_A}" "${WRITE_BODY}" > /dev/null
+STATUS=$(http GET "${FHIR_BASE}/DEFAULT/Composition?identifier=${WRITE_IDENT}" "${ADMIN_TOKEN}")
+TOTAL=$(jq -r '.total // (.entry | length) // 0' "${RESP_FILE}" 2>/dev/null || echo 0)
+if [[ "${STATUS}" == "200" && "${TOTAL}" == "0" ]]; then
+  pass "tenant_write_not_rerouted_to_default"
+else
+  fail "tenant_write_not_rerouted_to_default" "expected 200 + total=0 in DEFAULT, got status=${STATUS} total=${TOTAL}"
+fi
+
+# ------ test 10: Unauthenticated write is rejected -------------------------
+WRITE_IDENT="noauth-write-reject-$$-${RANDOM}"
+WRITE_BODY="$(build_resource_body Composition "${WRITE_IDENT}")"
+STATUS=$(http_no_auth POST "${FHIR_BASE}/${TENANT_A}/Composition" "${WRITE_BODY}")
+if [[ "${STATUS}" == "401" || "${STATUS}" == "403" ]]; then
+  pass "unauthenticated_write_rejected"
+else
+  fail "unauthenticated_write_rejected" "expected 401/403, got ${STATUS}"
+fi
+
+# ------ test 11: Anonymous denial for non-allowlisted type -----------------
+STATUS=$(http_no_auth GET "${FHIR_BASE}/${TENANT_A}/Patient")
+if [[ "${STATUS}" == "401" || "${STATUS}" == "403" ]]; then
+  pass "anonymous_denied_for_non_allowlisted_type"
+else
+  fail "anonymous_denied_for_non_allowlisted_type" "expected 401/403, got ${STATUS}"
 fi
 
 # ---------------------------------------------------------------------------

--- a/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/AppProperties.java
@@ -840,6 +840,13 @@ public Cors getCors() {
     // resolve to DEFAULT without forcing clients to qualify the ID.
     private Boolean allow_references_across_partitions = true;
 
+    // Resource types in this list are read from the DEFAULT partition even when requested
+    // via a per-tenant URL. Use for shared "config" resources (Composition, StructureMap, …)
+    // that HAPI's built-in non-partitionable list does not cover. Read-only — writes are not
+    // intercepted. Default value lives in application.yaml so operators can see it.
+    // Spring relaxed binding: yaml `default-only-resource-types` → Java `defaultOnlyResourceTypes`.
+    private List<String> default_only_resource_types = new ArrayList<>();
+
     public Boolean getPartitioning_include_in_search_hashes() {
       return partitioning_include_in_search_hashes;
     }
@@ -853,6 +860,14 @@ public Cors getCors() {
 
     public void setAllow_references_across_partitions(Boolean allow_references_across_partitions) {
       this.allow_references_across_partitions = allow_references_across_partitions;
+    }
+
+    public List<String> getDefault_only_resource_types() {
+      return default_only_resource_types;
+    }
+
+    public void setDefault_only_resource_types(List<String> default_only_resource_types) {
+      this.default_only_resource_types = default_only_resource_types;
     }
   }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authorization/SystemAwareRequestTenantPartitionInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/authnz/inbound/authorization/SystemAwareRequestTenantPartitionInterceptor.java
@@ -9,6 +9,12 @@ import ca.uhn.fhir.rest.api.server.RequestDetails;
 import ca.uhn.fhir.rest.api.server.SystemRequestDetails;
 import ca.uhn.fhir.rest.server.interceptor.partition.RequestTenantPartitionInterceptor;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+
 // Stock RequestTenantPartitionInterceptor throws when a request has no tenant.
 // Server-internal work (e.g. SearchParameter registry refresh on startup)
 // issues SystemRequestDetails without a URL tenant. Route those to the
@@ -23,12 +29,38 @@ import ca.uhn.fhir.rest.server.interceptor.partition.RequestTenantPartitionInter
 // would scope to the tenant partition and always return empty. We widen
 // non-partitionable reads to DEFAULT using HAPI's authoritative list via
 // IRequestPartitionHelperSvc#isResourcePartitionable.
+//
+// We additionally accept a configurable set of "default-only" resource types
+// (see hapi.fhir.partitioning.default-only-resource-types in application.yaml).
+// Resources of those types are also redirected to DEFAULT on read even when
+// requested from a per-tenant URL — this covers shared "config" resources
+// (Composition, StructureMap, …) that HAPI's built-in non-partitionable list
+// does not cover, and which our app fetches via tenant-scoped URLs before
+// login. WRITE-side interception is deliberately NOT added: writes against
+// /fhir/<tenant>/<Type> for these types stay tenant-scoped so a misconfigured
+// client cannot silently mutate the shared default-partition config.
 public class SystemAwareRequestTenantPartitionInterceptor extends RequestTenantPartitionInterceptor {
 
 	private final IRequestPartitionHelperSvc myPartitionHelperSvc;
+	private final Set<String> myAdditionalDefaultOnlyTypes;
 
 	public SystemAwareRequestTenantPartitionInterceptor(IRequestPartitionHelperSvc thePartitionHelperSvc) {
+		this(thePartitionHelperSvc, Collections.emptySet());
+	}
+
+	public SystemAwareRequestTenantPartitionInterceptor(
+			IRequestPartitionHelperSvc thePartitionHelperSvc,
+			Collection<String> theAdditionalDefaultOnlyTypes) {
 		this.myPartitionHelperSvc = thePartitionHelperSvc;
+		Set<String> lowered = new HashSet<>();
+		if (theAdditionalDefaultOnlyTypes != null) {
+			for (String t : theAdditionalDefaultOnlyTypes) {
+				if (t != null && !t.isEmpty()) {
+					lowered.add(t.toLowerCase(Locale.ROOT));
+				}
+			}
+		}
+		this.myAdditionalDefaultOnlyTypes = Collections.unmodifiableSet(lowered);
 	}
 
 	@Override
@@ -46,8 +78,11 @@ public class SystemAwareRequestTenantPartitionInterceptor extends RequestTenantP
 			return RequestPartitionId.defaultPartition();
 		}
 		String resourceType = theReadDetails != null ? theReadDetails.getResourceType() : null;
-		if (resourceType != null && !myPartitionHelperSvc.isResourcePartitionable(resourceType)) {
-			return RequestPartitionId.defaultPartition();
+		if (resourceType != null) {
+			if (!myPartitionHelperSvc.isResourcePartitionable(resourceType)
+					|| myAdditionalDefaultOnlyTypes.contains(resourceType.toLowerCase(Locale.ROOT))) {
+				return RequestPartitionId.defaultPartition();
+			}
 		}
 		return super.extractPartitionIdFromRequest(theRequestDetails);
 	}

--- a/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/common/StarterJpaConfig.java
@@ -451,7 +451,12 @@ public class StarterJpaConfig {
 
 		// Partitioning
 		if (appProperties.getPartitioning() != null) {
-			fhirServer.registerInterceptor(new SystemAwareRequestTenantPartitionInterceptor(requestPartitionHelperSvc));
+			List<String> defaultOnlyTypes = appProperties.getPartitioning().getDefault_only_resource_types();
+			if (defaultOnlyTypes == null) {
+				defaultOnlyTypes = Collections.emptyList();
+			}
+			fhirServer.registerInterceptor(
+				new SystemAwareRequestTenantPartitionInterceptor(requestPartitionHelperSvc, defaultOnlyTypes));
 			fhirServer.setTenantIdentificationStrategy(new UrlBaseTenantIdentificationStrategy());
 			fhirServer.registerProviders(partitionManagementProvider);
 		}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -164,9 +164,24 @@ hapi:
     # Keycloak JWT contains a partition_id claim matching the tenant name.
     # allow_references_across_partitions defaults to true so tenant writes can reference
     # definitional resources (Questionnaire, ValueSet, …) that live in DEFAULT only.
+    #
+    # default_only_resource_types: resource types in this list will be READ from the DEFAULT
+    # partition even when requested via a per-tenant URL. Use for shared "config" resources
+    # (Composition, StructureMap, …) that HAPI's built-in non-partitionable list doesn't
+    # cover. Read-only — writes are not intercepted (writes against /fhir/<tenant>/<Type>
+    # stay tenant-scoped so a misconfigured client cannot silently mutate shared config).
+    # The values shown below are the recommended defaults; the property itself takes effect
+    # only when the partitioning block is uncommented (i.e. multi-tenant mode is enabled).
     #partitioning:
     #  allow_references_across_partitions: true
     #  partitioning_include_in_search_hashes: false
+    #  default_only_resource_types:
+    #    - Composition
+    #    - StructureMap
+    #    - PlanDefinition
+    #    - Library
+    #    - Binary
+    #    - Location
     cors:
       allow_Credentials: true
       # These are allowed_origin patterns, see: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#setAllowedOriginPatterns-java.util.List-
@@ -285,6 +300,14 @@ hapi:
               arguments:
                 - Binary
                 - Composition
+                - Questionnaire
+                - StructureMap
+                - List
+                - PlanDefinition
+                - Library
+                - Measure
+                - Basic
+                - Parameters
             - name: fhir_transaction
             - name: fhir_capabilities
             - name: fhir_batch

--- a/src/test/java/ca/uhn/fhir/jpa/starter/MultitenantDefaultOnlyResourceTypesR4IT.java
+++ b/src/test/java/ca/uhn/fhir/jpa/starter/MultitenantDefaultOnlyResourceTypesR4IT.java
@@ -1,0 +1,107 @@
+package ca.uhn.fhir.jpa.starter;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.rest.api.CacheControlDirective;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import ca.uhn.fhir.rest.client.api.ServerValidationModeEnum;
+import ca.uhn.fhir.rest.client.interceptor.LoggingInterceptor;
+import ca.uhn.fhir.rest.client.interceptor.UrlTenantSelectionInterceptor;
+import ca.uhn.fhir.rest.server.provider.ProviderConstants;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.CodeType;
+import org.hl7.fhir.r4.model.Composition;
+import org.hl7.fhir.r4.model.IntegerType;
+import org.hl7.fhir.r4.model.Parameters;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the SystemAwareRequestTenantPartitionInterceptor's
+ * default-only-resource-types path: a Composition seeded in DEFAULT is
+ * readable via a per-tenant URL (e.g. /fhir/TENANT-A/Composition?identifier=…),
+ * because the read is transparently rerouted to DEFAULT.
+ *
+ * The matching application property is injected via @SpringBootTest properties.
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {Application.class}, properties =
+	{
+		"spring.datasource.url=jdbc:h2:mem:dbr4-mt-default-only",
+		"hapi.fhir.fhir_version=r4",
+		"hapi.fhir.cr_enabled=false",
+		"hapi.fhir.partitioning.partitioning_include_in_search_hashes=false",
+		"hapi.fhir.partitioning.default_only_resource_types[0]=Composition",
+		"hapi.fhir.partitioning.default_only_resource_types[1]=StructureMap",
+		"hapi.fhir.partitioning.default_only_resource_types[2]=Library",
+	})
+class MultitenantDefaultOnlyResourceTypesR4IT {
+
+	private IGenericClient ourClient;
+	private FhirContext ourCtx;
+
+	@LocalServerPort
+	private int port;
+
+	private static UrlTenantSelectionInterceptor ourClientTenantInterceptor;
+
+	@Test
+	void testDefaultOnlyCompositionReadFromTenantPartition() {
+
+		// Create TENANT-A
+		ourClientTenantInterceptor.setTenantId("DEFAULT");
+		ourClient
+			.operation()
+			.onServer()
+			.named(ProviderConstants.PARTITION_MANAGEMENT_CREATE_PARTITION)
+			.withParameter(Parameters.class, ProviderConstants.PARTITION_MANAGEMENT_PARTITION_ID, new IntegerType(1))
+			.andParameter(ProviderConstants.PARTITION_MANAGEMENT_PARTITION_NAME, new CodeType("TENANT-A"))
+			.execute();
+
+		// Seed a Composition in DEFAULT with a unique identifier
+		String identValue = "default-only-it-" + UUID.randomUUID();
+		Composition seed = new Composition();
+		seed.setStatus(Composition.CompositionStatus.FINAL);
+		seed.getType().setText("test");
+		seed.setTitle("default-only-it");
+		seed.getIdentifier().setSystem("urn:test").setValue(identValue);
+		seed.addAuthor().setDisplay("tester");
+
+		ourClientTenantInterceptor.setTenantId("DEFAULT");
+		String createdId = ourClient.create().resource(seed).execute().getId().getIdPart();
+
+		// Read via TENANT-A — should be transparently served from DEFAULT
+		ourClientTenantInterceptor.setTenantId("TENANT-A");
+		Bundle searchResult = ourClient.search()
+			.forResource(Composition.class)
+			.where(Composition.IDENTIFIER.exactly().systemAndValues("urn:test", identValue))
+			.returnBundle(Bundle.class)
+			.cacheControl(new CacheControlDirective().setNoCache(true))
+			.execute();
+
+		assertEquals(1, searchResult.getEntry().size(), "expected one Composition hit from TENANT-A search");
+		Composition found = (Composition) searchResult.getEntry().get(0).getResource();
+		assertTrue(found.getIdElement().getIdPart().equals(createdId),
+			"expected returned id to match the seeded DEFAULT id (created=" + createdId + ", found=" + found.getIdElement().getIdPart() + ")");
+	}
+
+	@BeforeEach
+	void beforeEach() {
+		ourClientTenantInterceptor = new UrlTenantSelectionInterceptor();
+		ourCtx = FhirContext.forR4();
+		ourCtx.getRestfulClientFactory().setServerValidationMode(ServerValidationModeEnum.NEVER);
+		ourCtx.getRestfulClientFactory().setSocketTimeout(1200 * 1000);
+		String ourServerBase = "http://localhost:" + port + "/fhir/";
+		ourClient = ourCtx.newRestfulGenericClient(ourServerBase);
+		ourClient.registerInterceptor(new LoggingInterceptor(true));
+		ourClient.registerInterceptor(ourClientTenantInterceptor);
+	}
+}

--- a/src/test/resources/keycloak/test-realm.json
+++ b/src/test/resources/keycloak/test-realm.json
@@ -13,6 +13,15 @@
       "config": {}
     }
   ],
+  "roles": {
+    "realm": [
+      {"name": "FHIR_READ_ALL_OF_TYPE"},
+      {"name": "FHIR_WRITE_ALL_OF_TYPE"},
+      {"name": "FHIR_EXTENDED_OPERATION_SUPERUSER"},
+      {"name": "FHIR_ALL_READ"},
+      {"name": "FHIR_ALL_WRITE"}
+    ]
+  },
   "clients": [
     {
       "clientId": "fhir-client",
@@ -33,6 +42,23 @@
             "jsonType.label": "String",
             "introspection.token.claim": "true"
           }
+        },
+        {
+          "name": "permission-argument-mapper",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "permission_argument",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "introspection.token.claim": "true",
+            "claim.name": "permission_argument",
+            "jsonType.label": "String",
+            "multivalued": "true",
+            "aggregate.attrs": "false"
+          }
         }
       ]
     }
@@ -47,8 +73,21 @@
       "emailVerified": true,
       "requiredActions": [],
       "attributes": {
-        "partition_id": ["TENANT-A"]
+        "partition_id": ["TENANT-A"],
+        "permission_argument": [
+          "FHIR_READ_ALL_OF_TYPE/Patient",
+          "FHIR_READ_ALL_OF_TYPE/Composition",
+          "FHIR_READ_ALL_OF_TYPE/Questionnaire",
+          "FHIR_READ_ALL_OF_TYPE/StructureMap",
+          "FHIR_READ_ALL_OF_TYPE/Library",
+          "FHIR_WRITE_ALL_OF_TYPE/Patient",
+          "FHIR_WRITE_ALL_OF_TYPE/Composition"
+        ]
       },
+      "realmRoles": [
+        "FHIR_READ_ALL_OF_TYPE",
+        "FHIR_WRITE_ALL_OF_TYPE"
+      ],
       "credentials": [{"type": "password", "value": "password", "temporary": false}]
     },
     {
@@ -60,8 +99,21 @@
       "emailVerified": true,
       "requiredActions": [],
       "attributes": {
-        "partition_id": ["TENANT-B"]
+        "partition_id": ["TENANT-B"],
+        "permission_argument": [
+          "FHIR_READ_ALL_OF_TYPE/Patient",
+          "FHIR_READ_ALL_OF_TYPE/Composition",
+          "FHIR_READ_ALL_OF_TYPE/Questionnaire",
+          "FHIR_READ_ALL_OF_TYPE/StructureMap",
+          "FHIR_READ_ALL_OF_TYPE/Library",
+          "FHIR_WRITE_ALL_OF_TYPE/Patient",
+          "FHIR_WRITE_ALL_OF_TYPE/Composition"
+        ]
       },
+      "realmRoles": [
+        "FHIR_READ_ALL_OF_TYPE",
+        "FHIR_WRITE_ALL_OF_TYPE"
+      ],
       "credentials": [{"type": "password", "value": "password", "temporary": false}]
     },
     {
@@ -72,6 +124,11 @@
       "enabled": true,
       "emailVerified": true,
       "requiredActions": [],
+      "realmRoles": [
+        "FHIR_ALL_READ",
+        "FHIR_ALL_WRITE",
+        "FHIR_EXTENDED_OPERATION_SUPERUSER"
+      ],
       "credentials": [{"type": "password", "value": "password", "temporary": false}]
     }
   ]


### PR DESCRIPTION
fhir-app fetches shared config (Composition, StructureMap, etc.) pre-login from per-tenant URLs, but those resources only live in the DEFAULT partition. Extend the partition interceptor with a configurable extra-types list and broaden the anonymous-read allowlist to cover the pre-login fetch set, so the app's startup config flow works on any tenant without exposing writes.